### PR TITLE
Refactoring NDT metric calculation to a separate module

### DIFF
--- a/testmaster/result_metrics.py
+++ b/testmaster/result_metrics.py
@@ -1,0 +1,68 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Provides a set of functions to calculate metrics for NDT results."""
+
+
+def total_duration(result):
+    """Calculates the total duration of an NDT result (in seconds).
+
+    Args:
+        result: An NdtResult instance.
+
+    Returns:
+        The total duration of the NDT result in seconds or None if the NDT test
+        did not complete.
+    """
+    return _calculate_duration(result)
+
+
+def c2s_duration(result):
+    """Calculates the duration of the c2s test of an NDT result (in seconds).
+
+    Args:
+        result: An NdtResult instance.
+
+    Returns:
+        The duration of the NDT c2s test in seconds or None if the c2s test did
+        not complete.
+    """
+    return _calculate_duration(result.c2s_result)
+
+
+def s2c_duration(result):
+    """Calculates the duration of the s2c test of an NDT result (in seconds).
+
+    Args:
+        result: An NdtResult instance.
+
+    Returns:
+        The duration of the NDT s2c test in seconds or None if the s2c test did
+        not complete.
+    """
+    return _calculate_duration(result.s2c_result)
+
+
+def _calculate_duration(event):
+    """Calculates the duration of an event in seconds.
+
+    Args:
+        event: An object that has start_time and end_time properties that
+            return datetime objects.
+
+    Returns:
+        The total duration of event in seconds.
+    """
+    if not event.start_time or not event.end_time:
+        return None
+    return (event.end_time - event.start_time).total_seconds()

--- a/tests/test_result_metrics.py
+++ b/tests/test_result_metrics.py
@@ -28,9 +28,7 @@ class ResultMetricsTest(unittest.TestCase):
         result = results.NdtResult(
             start_time=datetime.datetime(2016, 6, 8, 12, 0, 0, 0, pytz.utc),
             end_time=datetime.datetime(2016, 6, 8, 12, 0, 35, 700000, pytz.utc))
-        self.assertAlmostEqual(35.7,
-                               result_metrics.total_duration(result),
-                               places=1)
+        self.assertAlmostEqual(35.7, result_metrics.total_duration(result))
 
     def test_total_duration_is_None_on_incomplete_result(self):
         result = results.NdtResult(
@@ -42,9 +40,7 @@ class ResultMetricsTest(unittest.TestCase):
             start_time=datetime.datetime(2016, 6, 8, 12, 0, 0, 0, pytz.utc),
             end_time=datetime.datetime(2016, 6, 8, 12, 0, 11, 927345,
                                        pytz.utc)))
-        self.assertAlmostEqual(11.9,
-                               result_metrics.c2s_duration(result),
-                               places=1)
+        self.assertAlmostEqual(11.927345, result_metrics.c2s_duration(result))
 
     def test_c2s_duration_is_None_for_incomplete_c2s_test(self):
         result = results.NdtResult(c2s_result=results.NdtSingleTestResult(
@@ -56,9 +52,7 @@ class ResultMetricsTest(unittest.TestCase):
             start_time=datetime.datetime(2016, 6, 8, 12, 0, 0, 0, pytz.utc),
             end_time=datetime.datetime(2016, 6, 8, 12, 0, 11, 927345,
                                        pytz.utc)))
-        self.assertAlmostEqual(11.9,
-                               result_metrics.s2c_duration(result),
-                               places=1)
+        self.assertAlmostEqual(11.927345, result_metrics.s2c_duration(result))
 
     def test_s2c_duration_is_None_for_incomplete_s2c_test(self):
         result = results.NdtResult(s2c_result=results.NdtSingleTestResult(

--- a/tests/test_result_metrics.py
+++ b/tests/test_result_metrics.py
@@ -1,0 +1,66 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import datetime
+import unittest
+
+import pytz
+
+from testmaster import result_metrics
+from testmaster.ndt_e2e_clientworker.client_wrapper import results
+
+
+class ResultMetricsTest(unittest.TestCase):
+
+    def test_total_duration_is_correct_for_completed_result(self):
+        result = results.NdtResult(
+            start_time=datetime.datetime(2016, 6, 8, 12, 0, 0, 0, pytz.utc),
+            end_time=datetime.datetime(2016, 6, 8, 12, 0, 35, 700000, pytz.utc))
+        self.assertAlmostEqual(35.7,
+                               result_metrics.total_duration(result),
+                               places=1)
+
+    def test_total_duration_is_None_on_incomplete_result(self):
+        result = results.NdtResult(
+            start_time=datetime.datetime(2016, 6, 8, 12, 0, 0, 0, pytz.utc))
+        self.assertIsNone(result_metrics.total_duration(result))
+
+    def test_c2s_duration_is_correct_for_completed_c2s_test(self):
+        result = results.NdtResult(c2s_result=results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 6, 8, 12, 0, 0, 0, pytz.utc),
+            end_time=datetime.datetime(2016, 6, 8, 12, 0, 11, 927345,
+                                       pytz.utc)))
+        self.assertAlmostEqual(11.9,
+                               result_metrics.c2s_duration(result),
+                               places=1)
+
+    def test_c2s_duration_is_None_for_incomplete_c2s_test(self):
+        result = results.NdtResult(c2s_result=results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 6, 8, 12, 0, 0, 0, pytz.utc)))
+        self.assertIsNone(result_metrics.c2s_duration(result))
+
+    def test_s2c_duration_is_correct_for_completed_s2c_test(self):
+        result = results.NdtResult(s2c_result=results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 6, 8, 12, 0, 0, 0, pytz.utc),
+            end_time=datetime.datetime(2016, 6, 8, 12, 0, 11, 927345,
+                                       pytz.utc)))
+        self.assertAlmostEqual(11.9,
+                               result_metrics.s2c_duration(result),
+                               places=1)
+
+    def test_s2c_duration_is_None_for_incomplete_s2c_test(self):
+        result = results.NdtResult(s2c_result=results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 6, 8, 12, 0, 0, 0, pytz.utc)))
+        self.assertIsNone(result_metrics.s2c_duration(result))


### PR DESCRIPTION
Other modules in testmaster will need to calculate durations of tests in a
similar way to how csv_convert calculates it, so this refactors those
functions to their own reusable module.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-testmaster/5)

<!-- Reviewable:end -->
