### PR TITLE
Adding a module to calculate aggregate statistics

### DIFF
--- a/testmaster/aggregate.py
+++ b/testmaster/aggregate.py
@@ -1,0 +1,72 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy
+
+
+class Aggregates(object):
+    """A summary of aggregate statistics for a set of values."""
+
+    def __init__(self, minimum, maximum, mean, median, standard_deviation,
+                 sample_count):
+        self._minimum = minimum
+        self._maximum = maximum
+        self._mean = mean
+        self._median = median
+        self._standard_deviation = standard_deviation
+        self._sample_count = sample_count
+
+    @property
+    def minimum(self):
+        return self._minimum
+
+    @property
+    def maximum(self):
+        return self._maximum
+
+    @property
+    def mean(self):
+        return self._mean
+
+    @property
+    def median(self):
+        return self._median
+
+    @property
+    def standard_deviation(self):
+        return self._standard_deviation
+
+    @property
+    def sample_count(self):
+        return self._sample_count
+
+
+def aggregate(values):
+    """Calculates aggregate statistics for a set of numeric values.
+
+    Args:
+        values: A list of numeric values for which to calculate aggregate
+            statistics. Entries in the list that are None are ignored.
+
+    Returns:
+        An Aggregates instance representing aggregate statistics for the
+        specified values.
+    """
+    samples = [x for x in values if x is not None]
+    return Aggregates(minimum=min(samples),
+                      maximum=max(samples),
+                      mean=numpy.mean(samples),
+                      median=numpy.median(samples),
+                      standard_deviation=numpy.std(samples),
+                      sample_count=len(samples))

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -35,8 +35,7 @@ class AggregateTest(unittest.TestCase):
         self.assertAlmostEqual(14.0, aggregate_stats.maximum)
         self.assertAlmostEqual(8.0, aggregate_stats.mean)
         self.assertAlmostEqual(10.0, aggregate_stats.median)
-        self.assertAlmostEqual(5.8878405775518976,
-                               aggregate_stats.standard_deviation)
+        self.assertAlmostEqual(5.888, aggregate_stats.standard_deviation, 3)
         self.assertEqual(3, aggregate_stats.sample_count)
 
     def test_aggregate_ignores_None_values(self):
@@ -46,6 +45,5 @@ class AggregateTest(unittest.TestCase):
         self.assertAlmostEqual(14.0, aggregate_stats.maximum)
         self.assertAlmostEqual(8.0, aggregate_stats.mean)
         self.assertAlmostEqual(10.0, aggregate_stats.median)
-        self.assertAlmostEqual(5.8878405775518976,
-                               aggregate_stats.standard_deviation)
+        self.assertAlmostEqual(5.888, aggregate_stats.standard_deviation, 3)
         self.assertEqual(3, aggregate_stats.sample_count)

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,51 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import unittest
+
+from testmaster import aggregate
+
+
+class AggregateTest(unittest.TestCase):
+
+    def test_aggregate_single_value(self):
+        aggregate_stats = aggregate.aggregate([5.0])
+        self.assertAlmostEqual(5.0, aggregate_stats.minimum)
+        self.assertAlmostEqual(5.0, aggregate_stats.maximum)
+        self.assertAlmostEqual(5.0, aggregate_stats.mean)
+        self.assertAlmostEqual(5.0, aggregate_stats.median)
+        self.assertAlmostEqual(0.0, aggregate_stats.standard_deviation)
+        self.assertEqual(1, aggregate_stats.sample_count)
+
+    def test_aggregate_three_values(self):
+        aggregate_stats = aggregate.aggregate([0.0, 10.0, 14.0])
+        self.assertAlmostEqual(0.0, aggregate_stats.minimum)
+        self.assertAlmostEqual(14.0, aggregate_stats.maximum)
+        self.assertAlmostEqual(8.0, aggregate_stats.mean)
+        self.assertAlmostEqual(10.0, aggregate_stats.median)
+        self.assertAlmostEqual(5.8878405775518976,
+                               aggregate_stats.standard_deviation)
+        self.assertEqual(3, aggregate_stats.sample_count)
+
+    def test_aggregate_ignores_None_values(self):
+        """aggregate function should ignore None values."""
+        aggregate_stats = aggregate.aggregate([0.0, 10.0, None, 14.0])
+        self.assertAlmostEqual(0.0, aggregate_stats.minimum)
+        self.assertAlmostEqual(14.0, aggregate_stats.maximum)
+        self.assertAlmostEqual(8.0, aggregate_stats.mean)
+        self.assertAlmostEqual(10.0, aggregate_stats.median)
+        self.assertAlmostEqual(5.8878405775518976,
+                               aggregate_stats.standard_deviation)
+        self.assertEqual(3, aggregate_stats.sample_count)


### PR DESCRIPTION
Adding a module to calculate statistics. This is building towards allowing us to automate the task of producing the aggregate values for a set of NDT test results.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-testmaster/6)

<!-- Reviewable:end -->
